### PR TITLE
NaN Value Handing, Imputation, Value Dropping

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,7 +7,6 @@
     <list default="true" id="dddf0978-5059-481d-b500-f9f584531bb1" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pages/data_preprocessing.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/data_preprocessing.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pages/sup_learn.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/sup_learn.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,6 +7,8 @@
     <list default="true" id="dddf0978-5059-481d-b500-f9f584531bb1" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pages/data_preprocessing.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/data_preprocessing.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pages/sup_learn.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/sup_learn.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pages/unsup_learn.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/unsup_learn.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -8,7 +8,6 @@
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pages/data_preprocessing.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/data_preprocessing.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pages/sup_learn.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/sup_learn.py" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pages/unsup_learn.py" beforeDir="false" afterPath="$PROJECT_DIR$/pages/unsup_learn.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -55,7 +54,7 @@
     &quot;Python.main.executor&quot;: &quot;Run&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;imputing&quot;,
     &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;
   }
 }</component>

--- a/pages/data_preprocessing.py
+++ b/pages/data_preprocessing.py
@@ -257,11 +257,14 @@ if data is not None:
         # Update session state
         st.session_state.update({
             'X_train': X_train,
+            'X_train_index' : X_train.index,
             'X_test': X_test,
+            'X_test_index' : X_test.index,
             'y_train': y_train,
             'y_test': y_test,
             'X_raw': X,
             'y_raw': y
+
         })
     #Begin  Encoding Code
     st.subheader('Encoding')

--- a/pages/sup_learn.py
+++ b/pages/sup_learn.py
@@ -61,7 +61,7 @@ if 'data_file_data' in st.session_state:
             if 'sup_raw_scaler' in st.session_state:
                 data_options['Scaled'] = ('X_train_scaled', 'X_test_scaled')
 
-            if 'sup_encoder' and 'sup_raw_scaler' in st.session_state:
+            if 'X_train_encode_scaled' in st.session_state and 'sup_raw_scaler' in st.session_state:
                 data_options['Encoded & Scaled'] = ('X_train_encode_scaled', 'X_test_encode_scaled')
 
 
@@ -510,6 +510,10 @@ if 'data_file_data' in st.session_state:
                     except ValueError as e:
                         st.write(f"X_train shape: {X_train.shape}, y_train shape: {y_train.shape}")
                         st.write(f"X_test shape: {X_test.shape}, y_test shape: {y_test.shape}")
+                        st.subheader("X train dataframe")
+                        st.dataframe(X_train)
+                        st.subheader("X test dataframe")
+                        st.dataframe(X_test)
                         st.error(f"Model fitting failed: {e}")
                         st.stop()
 

--- a/pages/sup_learn.py
+++ b/pages/sup_learn.py
@@ -801,6 +801,15 @@ if 'data_file_data' in st.session_state:
                             with st.spinner("Generating SHAP values..."):
                                 model_type = type(selected_model)
                                 test_sample = X_test[:50] if len(X_test) > 50 else X_test
+
+                                if isinstance(X_train, np.ndarray):
+                                    X_train = pd.DataFrame(X_train,
+                                                           columns=[f'PC{i + 1}' for i in range(X_train.shape[1])],
+                                                           index=st.session_state['X_train_index'])
+                                    X_test = pd.DataFrame(X_test,
+                                                          columns=[f'PC{i + 1}' for i in range(X_test.shape[1])],
+                                                          index=st.session_state['X_test_index'])
+
                                 background_data = X_train.sample(n=min(100, len(X_train)), random_state=42)
 
                                 if model_type in [RandomForestClassifier, RandomForestRegressor,

--- a/pages/unsup_learn.py
+++ b/pages/unsup_learn.py
@@ -32,33 +32,34 @@ if 'data_file_data' in st.session_state:
     random_state = 42
     with col1:
 
-        data_choices = ['Raw', 'Scaled']
+        data_choices = ['Raw']
 
-        if 'sup_encoder' in st.session_state:
+
+        if 'sup_raw_scaler' in st.session_state and 'X_scaled' in st.session_state:
+            data_choices.append('Scaled')
+        if 'sup_encoder' in st.session_state and 'X_encoded' in st.session_state:
             data_choices.append('Encoded')
-            data_choices.append('Encoded & Scaled')
+            if 'sup_encode_scaler' in st.session_state and 'X_encoded_scaled':
+                data_choices.append('Encoded & Scaled')
 
 
         data_form = st.radio(label='Select Form of Data',
-                             options=['Raw', 'Encoded', 'Scaled', 'Encoded & Scaled'],
-                             horizontal=True,
-                             captions=['Raw data',
-                                       'Encoded data ',
-                                       'Scaled data',
-                                       'Encoded and scaled data'])
+                             options=data_choices,
+                             horizontal=True)
 
         if data_form == 'Raw':
             X = st.session_state['X_raw']
             X = X.select_dtypes(include='number')
-            st.warning("Non-numerical features will be dropped when handling raw data")
+            if len(st.session_state['cat_features']) > 0:
+                st.warning("Non-numerical features will be dropped when handling raw data")
 
-        elif data_form == 'Encoded':
+        elif data_form == 'Encoded' and 'X_encoded' in st.session_state:
             X = st.session_state['X_encoded']
 
-        elif data_form == 'Scaled':
+        elif data_form == 'Scaled' and 'X_scaled' in st.session_state:
             X = st.session_state['X_scaled']
 
-        else:
+        elif 'X_encoded_scaled' in st.session_state:
             X = st.session_state['X_encoded_scaled']
 
         y = st.session_state['y_raw']


### PR DESCRIPTION
When a dataset with NaN values is detected, a new selectbox now opens with some data cleaning options. The user can elect to 1. Drop values. This will drop all rows with a missing feature or target variable.
2. Employ SimpleImputer. The user can select from mean, median, or mode, imputation for their numerical features. Categorical features automatically have mode imputation applied.
In addition, a few bugs were resolved and some poor code practices were fixed.